### PR TITLE
Migrate build-app.py from closurebuilder.py

### DIFF
--- a/build-app.py
+++ b/build-app.py
@@ -181,22 +181,24 @@ def trim_licence(code):
 
 def write_compressed(name, lang):
   print('\n%s - %s - compressed:' % (name.title(), lang))
-  cmd = ['third-party/build/closurebuilder.py',
-      '--root=appengine/third-party/',
-      '--root=appengine/generated/%s/' % lang,
-      '--root=appengine/js/',
-      '--namespace=%s' % name.replace('/', '.').title(),
-      '--compiler_jar=third-party/closure-compiler.jar',
-      '--compiler_flags=--compilation_level=ADVANCED_OPTIMIZATIONS',
-      '--compiler_flags=--externs=externs/svg-externs.js',
-      '--compiler_flags=--externs=externs/interpreter-externs.js',
-      '--compiler_flags=--externs=externs/gviz-externs.js',
-      '--compiler_flags=--language_in=ECMASCRIPT5_STRICT',
-      '--output_mode=compiled']
+  cmd = ['java', '-jar', 'third-party/closure-compiler.jar',
+         '--js_output_file', 'compiled',
+         '--compilation_level=ADVANCED_OPTIMIZATIONS',
+         '--externs=externs/svg-externs.js',
+         '--externs=externs/interpreter-externs.js',
+         '--externs=externs/gviz-externs.js',
+         '--language_in=ECMASCRIPT5_STRICT',
+         '--dependency_mode=STRICT',
+         '--entry_point=%s' % name.replace('/', '.').title(),
+         '--js', 'appengine/third-party/**.js',
+                 'appengine/generated/%s/**.js' % lang,
+                 'appengine/js/**.js',
+                 '!appengine/**test.js']
+
   directory = name
   while(directory):
-    cmd.append('--root=appengine/%s/generated/%s/' % (directory, lang))
-    cmd.append('--root=appengine/%s/js/' % directory)
+    cmd.append('appengine/%s/generated/%s/**.js' % (directory, lang))
+    cmd.append('appengine/%s/js/**.js' % directory)
     (directory, sep, fragment) = directory.rpartition(os.path.sep)
   proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
   script = proc.stdout.readlines()

--- a/build-app.py
+++ b/build-app.py
@@ -187,7 +187,7 @@ def write_compressed(name, lang):
          '--externs=externs/svg-externs.js',
          '--externs=externs/interpreter-externs.js',
          '--externs=externs/gviz-externs.js',
-         '--language_in=ECMASCRIPT5_STRICT',
+         '--language_in=ECMASCRIPT6_STRICT',
          '--dependency_mode=STRICT',
          '--entry_point=%s' % name.replace('/', '.').title(),
          '--js', 'appengine/third-party/**.js',


### PR DESCRIPTION
Use of closurebuilder.py is deprecated now that the Closure compiler
handles the dependencies on its own, thus this patch removes the call to
closurebuilder.py to produce the compressed js output.

I was kind of annoyed by the warning messages saying: 
```
third-party/build/closurebuilder.py: Closure Compiler now natively understands and orders Closure dependencies and
is prefererred over using this script for performing JavaScript compilation.

Please migrate your codebase.
```
so I put this patch together. 

The second commit switches from ECMASCRIPT5 to ECMASCRIPT6 since
this is necessary for some third party libraries.

The new build process works however, it slows down compilation noticeably.
This may have to do with the dependency mode.

I'm a real beginner with the Closure library and build process so I may have messed
things up. :-)