### PR TITLE
Add Hausa to languages dropdown

### DIFF
--- a/appengine/common/boot.js
+++ b/appengine/common/boot.js
@@ -31,10 +31,10 @@
   // Supported languages (consistent across all apps).
   window['BlocklyGamesLanguages'] = [
     'ar', 'be', 'be-tarask', 'bg', 'bn', 'br', 'cs', 'da', 'de', 'el',
-    'en', 'es', 'eu', 'fa', 'fi', 'fr', 'gl', 'he', 'hi', 'hu', 'hy',
-    'ia', 'id', 'is', 'it', 'ja', 'kab', 'ko', 'lt', 'lv', 'ms', 'my',
-    'nb', 'nl', 'pl', 'pms', 'pt', 'pt-br', 'ru', 'sc', 'sk', 'sl', 'sq',
-    'sr', 'sv', 'th', 'tr', 'uk', 'ur', 'vi', 'zh-hans', 'zh-hant'
+    'en', 'es', 'eu', 'fa', 'fi', 'fr', 'gl', 'ha', 'he', 'hi', 'hu',
+    'hy', 'ia', 'id', 'is', 'it', 'ja', 'kab', 'ko', 'lt', 'lv', 'ms',
+    'my', 'nb', 'nl', 'pl', 'pms', 'pt', 'pt-br', 'ru', 'sc', 'sk', 'sl',
+    'sq', 'sr', 'sv', 'th', 'tr', 'uk', 'ur', 'vi', 'zh-hans', 'zh-hant'
   ];
 
   // Use a series of heuristics that determine the likely language of this user.

--- a/appengine/js/lib-games.js
+++ b/appengine/js/lib-games.js
@@ -57,6 +57,7 @@ BlocklyGames.LANGUAGE_NAME = {
   'fr': 'Français',
 //  'frr': 'Frasch',
   'gl': 'Galego',
+  'ha': 'Hausa',
 //  'hak': '客家話',
   'he': 'עברית',
   'hi': 'हिन्दी',


### PR DESCRIPTION
Now that the Hausa translations that my group has been working on are in the repo, I'd like to add the language to the dropdown.

Preview: https://mapmeld.com/blockly-games/appengine/maze.html

The core Blockly translations are available as JSON in the develop branch, but apparently not as JS until the next release. If this PR needs to wait until that release, that's OK too