### PR TITLE
Adding datastore interaction to online pond

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -106,6 +106,15 @@ handlers:
 - url: /pond/
   static_dir: pond
   secure: always
+- url: /pond-storage/create
+  script: pond_storage/create.py
+  secure: always
+- url: /pond-storage/update
+  script: pond_storage/update.py
+  secure: always
+- url: /pond-storage/delete
+  script: pond_storage/delete.py
+  secure: always
 
 # Genetics app.
 - url: /genetics

--- a/appengine/js/lib-interface.js
+++ b/appengine/js/lib-interface.js
@@ -134,21 +134,30 @@ BlocklyInterface.getCode = function() {
     var text = BlocklyInterface.editor['getValue']();
   } else {
     // Blockly editor.
-    var xml = Blockly.Xml.workspaceToDom(BlocklyGames.workspace, true);
-    // Remove x/y coordinates from XML if there's only one block stack.
-    // There's no reason to store this, removing it helps with anonymity.
-    if (BlocklyGames.workspace.getTopBlocks(false).length == 1 &&
-        xml.querySelector) {
-      var block = xml.querySelector('block');
-      if (block) {
-        block.removeAttribute('x');
-        block.removeAttribute('y');
-      }
-    }
-    var text = Blockly.Xml.domToText(xml);
+    var text = BlocklyInterface.getXml();
   }
   return text;
 };
+
+/**
+ * Get the user's XML code from the Blockly editor.
+ * @return {string} XML.
+ */
+BlocklyInterface.getXml = function() {
+  var xml = Blockly.Xml.workspaceToDom(BlocklyGames.workspace, true);
+  // Remove x/y coordinates from XML if there's only one block stack.
+  // There's no reason to store this, removing it helps with anonymity.
+  if (BlocklyGames.workspace.getTopBlocks(false).length == 1 &&
+      xml.querySelector) {
+    var block = xml.querySelector('block');
+    if (block) {
+      block.removeAttribute('x');
+      block.removeAttribute('y');
+    }
+  }
+  return Blockly.Xml.domToText(xml);
+};
+
 
 /**
  * Return the main workspace.

--- a/appengine/pond-online.html
+++ b/appengine/pond-online.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="pond/duck/style.css">
   <script src="third-party/ace/ace.js"></script>
   <script src="common/boot.js"></script>
+  <script src="/common/storage.js"></script>
 </head>
 <body>
 </body>

--- a/appengine/pond/online/template.soy
+++ b/appengine/pond/online/template.soy
@@ -37,6 +37,18 @@
     {/call}
   </h1>
 
+  <button id="createButton">
+    Create your Duck
+  </button>
+
+  <button id="updateButton">
+    Update a Duck
+  </button>
+
+  <button id="deleteButton">
+    Delete a Duck
+  </button>
+
   {call Pond.soy.visualization /}
 
   <div id="tabarea">
@@ -49,6 +61,8 @@
     <div id="editor"></div>
   </div>
 
+  {call .databaseDialogs /}
+
   {call .toolbox /}
   {call .playerRabbit /}
   {call .playerCounter /}
@@ -56,7 +70,95 @@
   {call .playerSniper /}
 
   {call BlocklyGames.soy.dialog /}
+  {call BlocklyGames.soy.doneDialog /}
+  {call BlocklyGames.soy.abortDialog /}
+  {call BlocklyGames.soy.storageDialog /}
+{/template}
 
+
+/**
+ * Toolbox.
+ */
+{template .databaseDialogs}
+  <div id="duckCreateDialog" class="dialogHiddenContent">
+    <form id="duckCreateForm" action="/pond-storage/create" method="post" onsubmit="return false">
+      <header>Create a duck</header>
+      <div>User id:
+        {sp}
+        <input id="createUserId" type="text" name="userid" required>
+      </div>
+      <div>Duck name:
+        {sp}
+        <input id="createName" type="text" name="name" required>
+      </div>
+      <input id="createJs" type="hidden" name="js">
+      <input id="createXml" type="hidden" name="xml">
+      <footer><!--Legal disclaimer goes here if needed.--></footer>
+
+      <div class="farSide">
+        <button id="duckCreateCancel" type="button">
+          {{msg meaning="Games.dialogCancel" desc="IBID"}}Cancel{{/msg}}
+        </button>
+        <button id="duckCreateOk" class="secondary" type="submit">
+          {{msg meaning="Games.dialogOk" desc="IBID"}}OK{{/msg}}
+        </button>
+      </div>
+    </form>
+  </div>
+
+  <div id="duckUpdateDialog" class="dialogHiddenContent">
+    <form id="duckUpdateForm" action="/pond-storage/update" method="post" onsubmit="return false">
+      <header>Update a duck</header>
+      <div>URL-safe Duck key:
+        {sp}
+        <input id="updateDuckKey" type="text" name="key" required>
+      </div>
+      <div>User id:
+        {sp}
+        <input id="updateUserId" type="text" name="userid" required>
+      </div>
+      <div>New duck name:
+        {sp}
+        <input id="updateName" type="text" name="name">
+      </div>
+      <input id="updateJs" type="hidden" name="js">
+      <input id="updateXml" type="hidden" name="xml">
+      <footer><!--Legal disclaimer goes here if needed.--></footer>
+
+      <div class="farSide">
+        <button id="duckUpdateCancel" type="button">
+          {{msg meaning="Games.dialogCancel" desc="IBID"}}Cancel{{/msg}}
+        </button>
+        <button id="duckUpdateOk" class="secondary" type="submit">
+          {{msg meaning="Games.dialogOk" desc="IBID"}}OK{{/msg}}
+        </button>
+      </div>
+    </form>
+  </div>
+
+  <div id="duckDeleteDialog" class="dialogHiddenContent">
+    <form id="duckDeleteForm" action="/pond-storage/delete" method="post" onsubmit="return false">
+      <header>Delete a duck</header>
+      <div>URL-safe Duck key:
+        {sp}
+        <input id="deleteDuckKey" type="text" name="key" required>
+      </div>
+      <div>User id:
+        {sp}
+        <input id="deleteUserId" type="text" name="userid" required>
+      </div>
+      <footer><!--Legal disclaimer goes here if needed.--></footer>
+
+      <div class="farSide">
+        <button id="duckDeleteCancel" type="button">
+          {{msg meaning="Games.dialogCancel" desc="IBID"}}Cancel{{/msg}}
+        </button>
+        <button id="duckDeleteOk" class="secondary" type="submit">
+          {{msg meaning="Games.dialogOk" desc="IBID"}}OK{{/msg}}
+        </button>
+      </div>
+    </form>
+  </div>
 {/template}
 
 /**

--- a/appengine/pond_storage/__init__.py
+++ b/appengine/pond_storage/__init__.py
@@ -1,0 +1,1 @@
+from common import *

--- a/appengine/pond_storage/common.py
+++ b/appengine/pond_storage/common.py
@@ -1,0 +1,47 @@
+"""Blockly Games: Pond Online
+
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Pond online's datastore models.
+"""
+
+__author__ = "kozbial@google.com (Monica Kozbial)"
+
+from google.appengine.ext import ndb
+
+class Code(ndb.Model):
+  js = ndb.TextProperty(required=True)
+  opt_xml = ndb.TextProperty()
+
+class Duck(ndb.Model):
+  userid = ndb.StringProperty()  # hashed google id
+  name = ndb.StringProperty(indexed=False, required=True)
+  code = ndb.LocalStructuredProperty(Code, indexed=False, required=True)
+
+  @classmethod
+  def _pre_delete_hook(cls, key):
+    le = key.get().leaderboard_entry
+    if le:
+      le.delete()
+
+class LeaderboardEntry(ndb.Model):
+  duck_key = ndb.KeyProperty(kind=Duck, indexed=False, required=True)
+  leaderboard = ndb.TextProperty(default='main')
+  instability = ndb.FloatProperty(required=True)
+  ranking = ndb.IntegerProperty(required=True)
+
+Duck.leaderboard_entry = ndb.KeyProperty(indexed=False, kind=LeaderboardEntry)
+Duck._fix_up_properties()

--- a/appengine/pond_storage/create.py
+++ b/appengine/pond_storage/create.py
@@ -1,0 +1,47 @@
+"""Blockly Games: Pond Online
+
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Create and upload a new duck 
+"""
+
+__author__ = "kozbial@google.com (Monica Kozbial)"
+
+import cgi
+import json
+from pond_storage import *
+
+forms = cgi.FieldStorage()
+userid = forms["userid"].value
+# Verify user does not have too many Ducks
+max_ducks = 10
+owned_ducks_query = Duck.query(Duck.userid == userid)
+owned_ducks_count = owned_ducks_query.count(limit=max_ducks)
+if owned_ducks_count == 10:
+  # There are too many ducks!!
+  print("Status: 403 Owner has too many ducks")
+else:
+  print("Content-Type: text/plain\n")
+  # Create a new Duck entry
+  js = forms["js"].value
+  name = forms["name"].value
+  code = Code(js=js)
+  if forms.has_key("xml"):
+    code.opt_xml = forms["xml"].value
+  duck = Duck(userid=userid, name=name, code=code)
+  duck_key = duck.put()
+  meta = {"duck_key": duck_key.urlsafe()}
+  print(json.dumps(meta))

--- a/appengine/pond_storage/delete.py
+++ b/appengine/pond_storage/delete.py
@@ -1,0 +1,46 @@
+"""Blockly Games: Pond Online
+
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Delete the specified Duck 
+"""
+
+__author__ = "kozbial@google.com (Monica Kozbial)"
+
+import cgi
+import json
+from google.appengine.ext import ndb
+from pond_storage import *
+
+forms = cgi.FieldStorage()
+urlsafe_key = forms["key"].value
+duck_key = ndb.Key(urlsafe=urlsafe_key)
+duck = duck_key.get()
+# Verify Duck exists in database
+if not duck:
+  # Duck with specified key does not exist.
+  print("Status: 400 Unknown Duck key")
+else:
+  # Verify user is allowed to update this Duck, i.e. is owner
+  userid = forms["userid"].value
+  if userid != duck.userid:
+    # User cannot delete this duck (user is not owner).
+    print("Status: 401 Unauthorized")
+  else:
+    print("Content-Type: text/plain\n")
+    duck.key.delete()
+    meta = {"duck_key": duck_key.urlsafe()}
+    print(json.dumps(meta))

--- a/appengine/pond_storage/update.py
+++ b/appengine/pond_storage/update.py
@@ -1,0 +1,55 @@
+"""Blockly Games: Pond Online
+
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Update the specified Duck 
+"""
+
+__author__ = "kozbial@google.com (Monica Kozbial)"
+
+import cgi
+import json
+from google.appengine.ext import ndb
+from pond_storage import *
+
+forms = cgi.FieldStorage()
+urlsafe_key = forms["key"].value
+duck_key = ndb.Key(urlsafe=urlsafe_key)
+duck = duck_key.get()
+# Verify Duck exists in database
+if not duck:
+  # Duck with specified key does not exist.
+  print("Status: 400 Unknown Duck key")
+else:
+  # Verify user is allowed to update this Duck, i.e. is owner
+  userid = forms["userid"].value
+  if userid != duck.userid:
+    # User cannot delete this duck (user is not owner).
+    print("Status: 401 Unauthorized")
+  else:
+    print("Content-Type: text/plain\n")
+    # Update duck information
+    duck.code.js = forms["js"].value
+    if forms.has_key("xml"):
+      duck.code.opt_xml = forms["xml"].value
+    else:
+      del duck.code.opt_xml     
+    if forms.has_key("name"):
+      name = forms["name"].value
+      duck.name = name
+    duck.put()
+    meta = {"duck_key": duck_key.urlsafe()}
+    print(json.dumps(meta))


### PR DESCRIPTION
Added buttons and logic for interacting with datastore and buttons on the Pond online app:
![image](https://user-images.githubusercontent.com/6621618/68629486-e878ea80-0498-11ea-822d-52565c626c0b.png)

Including:
- Creating a new Duck
- Updating a Duck
- Deleting a Duck