### PR TITLE
Fixing msg error on gallery.

### DIFF
--- a/appengine/gallery/js/gallery.js
+++ b/appengine/gallery/js/gallery.js
@@ -42,7 +42,7 @@ Gallery.init = function() {
     document.body.className = 'admin';
   }
   // Render the Soy template.
-  // First, just render the messages.
+  // First, render the messages so we can access the app name.
   document.body.innerHTML = Gallery.soy.messages({}, null, {});
   // Second, look up the app name message.
   var appName = isAdmin ?

--- a/appengine/gallery/template.soy
+++ b/appengine/gallery/template.soy
@@ -11,6 +11,13 @@
  */
 
 /**
+ * Translated messages for use in JavaScript.
+ */
+{template .messages}
+  {call BlocklyGames.soy.messages /}
+{/template}
+
+/**
  * Web page structure.
  */
 {template .start}


### PR DESCRIPTION
Adding back call to render messages.
BlocklyGames.mesages need to be rendered so that the app name can be retrieved. Comment was updated for clarification.