### PR TITLE
Handling promise rejection for sound.play()

### DIFF
--- a/appengine/pond/js/visualization.js
+++ b/appengine/pond/js/visualization.js
@@ -424,7 +424,7 @@ Pond.Visualization.preloadAudio_ = function() {
   for (var name in Pond.Visualization.SOUNDS_) {
     var sound = Pond.Visualization.SOUNDS_[name];
     sound.volume = .01;
-    sound.play();
+    sound.play().catch(function() {});
     sound.pause();
   }
 };


### PR DESCRIPTION
Prevents uncaught promise error on load of Pond game.
Based on https://github.com/google/blockly/pull/2162