### PR TITLE
Update unpublishing logic.

### DIFF
--- a/appengine/pond_storage/common.py
+++ b/appengine/pond_storage/common.py
@@ -58,17 +58,6 @@ class Duck(ndb.Model):
       return True
     return False
 
-def get_dummy_duck_key():
-  """Creates a dummy duck (always throws)."""
-  dummy_duck_id = 'dummy'
-  dummy_duck_key = ndb.Key(Duck, dummy_duck_id)
-  # Create entity if it does not exist.
-  if not dummy_duck_key.get():
-    dummy_code = Code(js='throw "dummy duck";')
-    dummy_duck = Duck(id=dummy_duck_id, name='', code=dummy_code)
-    dummy_duck.put()
-  return  dummy_duck_key
-
 class LeaderboardEntry(ndb.Model):
   """Entry in leaderboard, storing ranking information.
 
@@ -77,10 +66,11 @@ class LeaderboardEntry(ndb.Model):
   leaderboard_key = ndb.KeyProperty(kind='Leaderboard', required=True)
   ranking = ndb.IntegerProperty(required=True)
   instability = ndb.FloatProperty(required=True)
-  duck_key = ndb.KeyProperty(kind=Duck, indexed=False, required=True)
+  duck_key = ndb.KeyProperty(kind=Duck, indexed=False)
+  is_dummy = ndb.ComputedProperty(lambda self: self.duck_key is None)
 
   def clear_duck(self):
-    self.duck_key = get_dummy_duck_key()
+    del self.duck_key
     self.put()
 
   def update_ranking(self, new_rank):

--- a/appengine/pond_storage/opponents.py
+++ b/appengine/pond_storage/opponents.py
@@ -135,22 +135,21 @@ def entries_to_duck_info(entries):
       'code': {'js': 'some code', 'opt_xml': 'some xml'},
       'published': 'true',
     }
-  """  
+  """
   ducks = []
-  #TODO: This can be updated when we deal with dummy ducks
   for entry in entries:
-    duck = entry.duck_key.get()
-    if (duck):
-      duck_info = get_duck_info(duck)
-      ducks.append(duck_info)
-    else:
+    if entry.is_dummy:
+      # TODO: handle/filter dummy entries earlier.
       duck_info = {
-        'name': "dummy",
-        'duck_key': 'aKey',
-        'code': {'js':'throw "dummy duck";'},
-        'publish':'true'
+          'name': "dummy",
+          'duck_key': 'aKey',
+          'code': {'js':'throw "dummy duck";'},
+          'publish':'true'
       }
-      ducks.append(duck_info)
+    else:
+      duck = entry.duck_key.get()
+      duck_info = get_duck_info(duck)
+    ducks.append(duck_info)
   return ducks
 
 def get_opponents(user_entry):

--- a/appengine/pond_storage/rank.py
+++ b/appengine/pond_storage/rank.py
@@ -53,15 +53,14 @@ def create_ranking_match():
             js: The javascript code for the duck associated with that entry
     Or None if no valid match can be created.
   """
-  # TODO handle dummy ducks.
+  # TODO handle dummy entries.
   # 1. Find the entry with the highest instability not in a match request.
   unstable_leaderboard_entry = None
   unstable_entries_query = (
       LeaderboardEntry.query().order(-LeaderboardEntry.instability))
   for entry in unstable_entries_query:
-    # Check if it exists in a current match request (ignoring dummy ducks)
-    if (not MatchRequest.contains_entry(entry.key) and
-        entry.duck_key != get_dummy_duck_key()):
+    # Check if it exists in a current match request (ignoring dummy entries)
+    if not MatchRequest.contains_entry(entry.key) and not entry.is_dummy:
       unstable_leaderboard_entry = entry
       break
   if not unstable_leaderboard_entry:
@@ -78,8 +77,7 @@ def create_ranking_match():
   leaderboard = unstable_leaderboard_entry.leaderboard_key.get()
   leaderboard_query = leaderboard.get_entries_query()
   for entry in leaderboard_query:
-    if (entry != unstable_leaderboard_entry and
-        entry.duck_key != get_dummy_duck_key() and
+    if (entry != unstable_leaderboard_entry and not entry.is_dummy and
         not MatchRequest.contains_entry(entry.key)):
       entry_keys.append(entry.key)
       duck_list.append({


### PR DESCRIPTION
Instead of assigning a leaderboard entry to a dummy duck, the duck key for an entry is cleared when its duck is unpublished.