### PR TITLE
Ui fixes

### DIFF
--- a/appengine/common/common.css
+++ b/appengine/common/common.css
@@ -71,6 +71,10 @@ xml {
 }
 
 /* Buttons */
+button:disabled {
+  color: lightgray;
+}
+
 button {
   margin: 5px;
   padding: 10px;

--- a/appengine/pond/duck/js/duck.js
+++ b/appengine/pond/duck/js/duck.js
@@ -280,6 +280,10 @@ Pond.Duck.editorChanged = function () {
       BlocklyInterface.workspace.clear();
       Pond.Duck.setBlocksEnabled(true);
     }
+    var saveBtn = document.getElementById('saveButton');
+    if (saveBtn) {
+      saveBtn.disabled = false;
+    }
   } else {
     if (!BlocklyInterface.workspace.getTopBlocks(false).length ||
         confirm(BlocklyGames.getMsg('Games_breakLink'))) {

--- a/appengine/pond/duck/online/js/online.js
+++ b/appengine/pond/duck/online/js/online.js
@@ -90,6 +90,12 @@ Pond.Duck.Online.init = function() {
     // Show Blockly editor tab.
     Pond.Duck.changeTab(Pond.Duck.TAB_INDEX.BLOCKLY);
   }
+  BlocklyGames.workspace.addChangeListener(function(){
+    var saveBtn = document.getElementById('saveButton');
+    if (saveBtn) {
+      saveBtn.disabled = false;
+    }
+  });
 };
 
 /**
@@ -183,12 +189,13 @@ Pond.Duck.Online.renderDuckInfo = function() {
 
   BlocklyGames.bindClick(
       'saveButton',
-      function() {
+      function(e) {
         Pond.Duck.Datastore.updateDuckCode(
             Pond.Duck.Online.duckKey,
             BlocklyInterface.getJsCode(),
             BlocklyInterface.blocksDisabled ? '' : BlocklyInterface.getXml(),
             Pond.Duck.Online.renderDuckInfo);
+        e.target.disabled = true;
       });
 };
 

--- a/appengine/pond/duck/online/js/online.js
+++ b/appengine/pond/duck/online/js/online.js
@@ -63,8 +63,6 @@ Pond.Duck.Online.init = function() {
   BlocklyGames.bindClick('duckListButton', Pond.Duck.Online.openDuckList_);
 
   BlocklyGames.bindClick('duckCreateButton', Pond.Duck.Online.showCreateDuckForm);
-  BlocklyGames.bindClick('duckUpdateButton', Pond.Duck.Online.showUpdateDuckForm);
-  BlocklyGames.bindClick('duckDeleteButton', Pond.Duck.Online.showDeleteDuckForm);
   BlocklyGames.bindClick('getOpponents', function() {
     Pond.Duck.Datastore.getOpponents(
         Pond.Duck.Online.duckKey,
@@ -164,20 +162,23 @@ Pond.Duck.Online.renderDuckInfo = function() {
     BlocklyGames.bindClick(
         'publishButton',
         function() {
-          Pond.Duck.Datastore.setPublished(
+          if (confirm(BlocklyGames.getMsg('Online_publishDuckDialog'))) {
+            Pond.Duck.Datastore.setPublished(
               Pond.Duck.Online.duckKey, true, Pond.Duck.Online.renderDuckInfo);
+          }
         });
   }
   BlocklyGames.bindClick(
       'deleteButton',
       function() {
-        Pond.Duck.Datastore.deleteDuck(
-            Pond.Duck.Online.duckKey, false,
+        if (confirm(BlocklyGames.getMsg('Online_deleteDuckDialog'))) {
+          Pond.Duck.Datastore.deleteDuck(Pond.Duck.Online.duckKey, false,
             function() {
               var url = window.location.origin
                   + '/pond-duck-online?lang='+ BlocklyGames.LANG;
               window.location = url;
             });
+        }
       });
 
   BlocklyGames.bindClick(

--- a/appengine/pond/duck/online/js/online.js
+++ b/appengine/pond/duck/online/js/online.js
@@ -88,7 +88,7 @@ Pond.Duck.Online.init = function() {
     // Show Blockly editor tab.
     Pond.Duck.changeTab(Pond.Duck.TAB_INDEX.BLOCKLY);
   }
-  BlocklyGames.workspace.addChangeListener(function(){
+  BlocklyInterface.workspace.addChangeListener(function(){
     var saveBtn = document.getElementById('saveButton');
     if (saveBtn) {
       saveBtn.disabled = false;
@@ -158,6 +158,7 @@ Pond.Duck.Online.renderDuckInfo = function() {
           Pond.Duck.Datastore.setPublished(
               Pond.Duck.Online.duckKey, false, Pond.Duck.Online.renderDuckInfo);
         });
+    document.getElementById('getOpponents').disabled = false;
   } else {
     BlocklyGames.bindClick(
         'publishButton',
@@ -167,6 +168,7 @@ Pond.Duck.Online.renderDuckInfo = function() {
               Pond.Duck.Online.duckKey, true, Pond.Duck.Online.renderDuckInfo);
           }
         });
+    document.getElementById('getOpponents').disabled = true;
   }
   BlocklyGames.bindClick(
       'deleteButton',

--- a/appengine/pond/duck/online/template.soy
+++ b/appengine/pond/duck/online/template.soy
@@ -44,6 +44,11 @@
     {param appName}
       Pond Online{sp}
     {/param}
+    {param farLeftHtml}
+      <button id="saveButton">
+        Save this Duck
+      </button>
+    {/param}
     {param tabareaHtml}
       <div id="editorBar" class="tab-bar">
         <div class="editor tab tab-selected">{{msg meaning="Games.blocks" desc="IBID"}}Blocks{{/msg}}</div>
@@ -102,9 +107,6 @@
     Copy this Duck
   </button>
   <br>
-  <button id="saveButton">
-    Save this Duck
-  </button>
 {/template}
 
 /**

--- a/appengine/pond/duck/online/template.soy
+++ b/appengine/pond/duck/online/template.soy
@@ -16,7 +16,7 @@
 {template .messages}
   {call Pond.Duck.soy.messages /}
   <div style="display: none">
-      <span id="Online_publishDuckDialog">{msg meaning="Online.publishDuckDialog" desc="Warning dialog. Options are 'OK' and 'Cancel'."}Are you sure you want to publish this duck?{/msg}</span>
+      <span id="Online_publishDuckDialog">{msg meaning="Online.publishDuckDialog" desc="Warning dialog. Options are 'OK' and 'Cancel'."}Publishing a duck allows other user's ducks to play against it. Is this OK?{/msg}</span>
       <span id="Online_deleteDuckDialog">{msg meaning="Online.deleteDuckDialog" desc="Warning dialog. Options are 'OK' and 'Cancel'."}Are you sure you want to delete this duck?{/msg}</span>
   </div>
 {/template}

--- a/appengine/pond/duck/online/template.soy
+++ b/appengine/pond/duck/online/template.soy
@@ -11,10 +11,21 @@
  */
 
 /**
+ * Translated messages for use in JavaScript.
+ */
+{template .messages}
+  {call Pond.Duck.soy.messages /}
+  <div style="display: none">
+      <span id="Online_publishDuckDialog">{msg meaning="Online.publishDuckDialog" desc="Warning dialog. Options are 'OK' and 'Cancel'."}Are you sure you want to publish this duck?{/msg}</span>
+      <span id="Online_deleteDuckDialog">{msg meaning="Online.deleteDuckDialog" desc="Warning dialog. Options are 'OK' and 'Cancel'."}Are you sure you want to delete this duck?{/msg}</span>
+  </div>
+{/template}
+
+/**
  * Web page structure.
  */
 {template .start}
-
+  {call .messages /}
   // TODO: move duck list button.
   <button id="duckListButton">
     Open Duck List
@@ -24,29 +35,13 @@
     Create your Duck
   </button>
 
-  <button id="duckUpdateButton">
-    Update a Duck
-  </button>
-
-  <button id="duckDeleteButton">
-    Delete a Duck
-  </button>
-
-  <button id="getOpponents">
-    Get Opponents
-  </button>
-
-  <button id="defaultOpponents">
-    Default Opponents
-  </button>
-
   {call Pond.Duck.soy.start}
     {param appName}
       Pond Online{sp}
     {/param}
     {param farLeftHtml}
       <button id="saveButton">
-        Save this Duck
+        {msg meaning="Online.saveDuck" desc="Text on the button used to save a duck."}Save{/msg}
       </button>
     {/param}
     {param tabareaHtml}
@@ -91,20 +86,20 @@
 
   {if $duck['published']}
     <button id="unPublishButton">
-      Unpublish this Duck
+      {msg meaning="Online.unpublishDuckButton" desc="Text on the button used to unpublish a duck."}Unpublish this Duck{/msg}
     </button>
   {else}
     <button id="publishButton">
-      Publish this Duck
+      {msg meaning="Online.publishDuckButton" desc="Text on the button used to publish a duck."}Publish this Duck{/msg}
     </button>
   {/if}
   <br>
   <button id="deleteButton">
-    Delete this Duck
+    {msg meaning="Online.deleteDuckButton" desc="Text on the button used to delete a duck."}Delete this Duck{/msg}
   </button>
   <br>
   <button id="copyButton">
-    Copy this Duck
+    {msg meaning="Online.copyDuckButton" desc="Text on the button used to copy a duck."}Copy this Duck{/msg}
   </button>
   <br>
 {/template}
@@ -146,52 +141,6 @@
           {{msg meaning="Games.dialogCancel" desc="IBID"}}Cancel{{/msg}}
         </button>
         <button id="duckCreateOk" class="secondary" type="submit">
-          {{msg meaning="Games.dialogOk" desc="IBID"}}OK{{/msg}}
-        </button>
-      </div>
-    </form>
-  </div>
-
-  <div id="duckUpdateDialog" class="dialogHiddenContent">
-    <form id="duckUpdateForm" action="/pond-storage/update" method="post" onsubmit="return false">
-      <header>Update a duck</header>
-      <div>URL-safe Duck key:
-        {sp}
-        <input id="duckUpdateDuckKey" type="text" name="key" required>
-      </div>
-      <div>New duck name:
-        {sp}
-        <input id="duckUpdateName" type="text" name="name">
-      </div>
-      <input id="duckUpdateJs" type="hidden" name="js">
-      <input id="duckUpdateXml" type="hidden" name="xml">
-      <footer><!--Legal disclaimer goes here if needed.--></footer>
-
-      <div class="farSide">
-        <button id="duckUpdateCancel" type="button">
-          {{msg meaning="Games.dialogCancel" desc="IBID"}}Cancel{{/msg}}
-        </button>
-        <button id="duckUpdateOk" class="secondary" type="submit">
-          {{msg meaning="Games.dialogOk" desc="IBID"}}OK{{/msg}}
-        </button>
-      </div>
-    </form>
-  </div>
-
-  <div id="duckDeleteDialog" class="dialogHiddenContent">
-    <form id="duckDeleteForm" action="/pond-storage/delete" method="post" onsubmit="return false">
-      <header>Delete a duck</header>
-      <div>URL-safe Duck key:
-        {sp}
-        <input id="duckDeleteDuckKey" type="text" name="key" required>
-      </div>
-      <footer><!--Legal disclaimer goes here if needed.--></footer>
-
-      <div class="farSide">
-        <button id="duckDeleteCancel" type="button">
-          {{msg meaning="Games.dialogCancel" desc="IBID"}}Cancel{{/msg}}
-        </button>
-        <button id="duckDeleteOk" class="secondary" type="submit">
           {{msg meaning="Games.dialogOk" desc="IBID"}}OK{{/msg}}
         </button>
       </div>

--- a/appengine/pond/duck/template.soy
+++ b/appengine/pond/duck/template.soy
@@ -38,10 +38,13 @@
     {param levelLinkSuffix}{/param}
     {param hasLinkButton: false /}
     {param hasHelpButton: false /}
+    {param hasDocButton: true /}
     {param farLeftHtml: $farLeftHtml/}
   {/call}
 
-  {call Pond.soy.visualization /}
+  {call Pond.soy.visualization}
+    {param appName: $appName/}
+  {/call}
 
   <div id="tabarea">
     {$tabareaHtml |noAutoescape}

--- a/appengine/pond/duck/template.soy
+++ b/appengine/pond/duck/template.soy
@@ -28,6 +28,7 @@
  * Web page structure.
  * @param appName Name of application.
  * @param tabareaHtml Html content of tabarea
+ * @param farLeftHtml Html content of left header bar
  */
 {template .start}
 
@@ -37,7 +38,7 @@
     {param levelLinkSuffix}{/param}
     {param hasLinkButton: false /}
     {param hasHelpButton: false /}
-    {param farLeftHtml}{/param}
+    {param farLeftHtml: $farLeftHtml/}
   {/call}
 
   {call Pond.soy.visualization /}

--- a/appengine/pond/template.soy
+++ b/appengine/pond/template.soy
@@ -29,6 +29,7 @@
 
 /**
  * Canvas, health bars, and buttons.
+ * @param appName Name of application.
  */
 {template .visualization}
   <div id="visualization">
@@ -44,11 +45,22 @@
   </table>
 
   <table width="400">
+    {if $appName == 'Pond Online'}
     <tr>
       <td style="width: 190px; text-align: center; vertical-align: top;">
-        <button id="docsButton" title="{msg meaning="Pond.docsTooltip" desc="Tooltip for the button that opens the language reference documentation."}Display the language documentation.{/msg}">
-          {{msg meaning="Pond.documentation" desc="Text on the button that opens the language reference documentation.\n{lb}{lb}Identical|Documentation{rb}{rb}"}}Documentation{{/msg}}
+        <button id="getOpponents">
+          {msg meaning="Pond.getOpponents" desc="Text on the button used to get opponents for the user to play against."}Get Opponents{/msg}
         </button>
+      </td>
+      <td style="width: 190px; text-align: center; vertical-align: top;">
+        <button id="defaultOpponents">
+          {msg meaning="Pond.defaultOpponents" desc="Text on the button used to get the default opponents for user to play against."}Default Opponents{/msg}
+        </button>
+      </td>
+    </tr>
+    {/if}
+    <tr>
+      <td style="width: 190px; text-align: center; vertical-align: top;">
       </td>
       <td>
         <button id="runButton" class="primary" title="{msg meaning="Games.runTooltip" desc="IBID"}Run the program you wrote.{/msg}">

--- a/appengine/pond/template.soy
+++ b/appengine/pond/template.soy
@@ -45,7 +45,7 @@
   </table>
 
   <table width="400">
-    {if $appName == 'Pond Online'}
+    {if $appName == 'Pond Online '}
     <tr>
       <td style="width: 190px; text-align: center; vertical-align: top;">
         <button id="getOpponents">

--- a/appengine/template.soy
+++ b/appengine/template.soy
@@ -82,6 +82,7 @@
  * @param levelLinkSuffix Any extra parameters for links.
  * @param hasLinkButton Whether the page has a link button.
  * @param hasHelpButton Whether the page has a help button.
+ * @param hasDocButton Whether the page has a documentation button.
  * @param farLeftHtml Additional content to add to farLeft toolbar.
  */
 {template .headerBar private="true"}
@@ -112,6 +113,12 @@
           &nbsp;
           <button id="helpButton">
             {{msg meaning="Games.help" desc="IBID"}}Help{{/msg}}
+          </button>
+        {/if}
+        {if $hasDocButton}
+          &nbsp;
+          <button id="docsButton" title="{msg meaning="Pond.docsTooltip" desc="Tooltip for the button that opens the language reference documentation."}Display the language documentation.{/msg}">
+            {{msg meaning="Games.documentation" desc="Text on the button that opens the language reference documentation.\n{lb}{lb}Identical|Documentation{rb}{rb}"}}Documentation{{/msg}}
           </button>
         {/if}
         {if $farLeftHtml}


### PR DESCRIPTION
1. Adds a Save button to the bar at the top. Save button disabled after a user clicks and enabled when user changes something in blockly editor or javascript editor.
2. Moves documentation button to the bar at the top. 
3. Moves the get opponent and get default opponent buttons underneath the pond game. 
4. Adds a confirmation dialog for publishing and deleting a duck 
5. Using msg for button text 

<img width="1676" alt="Screen Shot 2020-01-29 at 1 40 54 PM" src="https://user-images.githubusercontent.com/23059043/73401436-00922600-42a0-11ea-82ea-3c96941799a7.png">

Get Opponents button is disabled if the duck is not published.
<img width="415" alt="Screen Shot 2020-01-29 at 2 01 38 PM" src="https://user-images.githubusercontent.com/23059043/73401404-f2440a00-429f-11ea-9edc-ecad40c5e10f.png">
<img width="451" alt="Screen Shot 2020-01-29 at 2 01 19 PM" src="https://user-images.githubusercontent.com/23059043/73401405-f2440a00-429f-11ea-89cc-ec286f6932a2.png">
<img width="449" alt="Screen Shot 2020-01-29 at 1 41 24 PM" src="https://user-images.githubusercontent.com/23059043/73401426-fb34db80-429f-11ea-9810-e3e970d4f2f5.png">

Save button is disabled if a user has nothing new to save
<img width="472" alt="Screen Shot 2020-01-29 at 1 41 54 PM" src="https://user-images.githubusercontent.com/23059043/73401406-f2440a00-429f-11ea-8801-1e685bd408fd.png">


