### PR TITLE
Update Ui event api usages

### DIFF
--- a/appengine/maze/js/maze.js
+++ b/appengine/maze/js/maze.js
@@ -559,7 +559,7 @@ Maze.init = function() {
  * @param {Blockly.Events.Abstract=} opt_event Custom data for event.
  */
 Maze.levelHelp = function(opt_event) {
-  if (opt_event && opt_event.type == Blockly.Events.UI) {
+  if (opt_event && opt_event.isUiEvent) {
     // Just a change to highlighting or somesuch.
     return;
   } else if (BlocklyInterface.workspace.isDragging()) {

--- a/appengine/movie/js/movie.js
+++ b/appengine/movie/js/movie.js
@@ -351,7 +351,7 @@ Movie.drawFrame_ = function(interpreter) {
  * @param {!Blockly.Events.Abstract=} opt_e Change event.
  */
 Movie.codeChange = function(opt_e) {
-  if (opt_e instanceof Blockly.Events.Ui) {
+  if (opt_e.isUiEvent) {
     return;
   }
   if (BlocklyInterface.workspace.isDragging()) {

--- a/appengine/music/js/music.js
+++ b/appengine/music/js/music.js
@@ -501,7 +501,7 @@ Music.disableExtraStarts = function(e) {
  * @param {!Blockly.Events.Abstract} e Change event.
  */
 Music.disableSubmit = function(e) {
-  if (!(e instanceof Blockly.Events.Ui)) {
+  if (!e.isUiEvent) {
     Music.canSubmit = false;
   }
 };

--- a/appengine/turtle/js/turtle.js
+++ b/appengine/turtle/js/turtle.js
@@ -411,7 +411,7 @@ Turtle.categoryClicked_ = false;
  * @private
  */
 Turtle.watchCategories_ = function(event) {
-  if (event.type == Blockly.Events.UI && event.element == 'category') {
+  if (event.type == Blockly.Events.TOOLBOX_ITEM_SELECT) {
     Turtle.categoryClicked_ = true;
     BlocklyDialogs.hideDialog(false);
     BlocklyInterface.workspace.removeChangeListener(Turtle.watchCategories_);


### PR DESCRIPTION
Updates Blockly UI event usages to reflect changes made in Blockly core in upcoming release.

These fixes affect the following cases:
- Maze - don't check for new help text if there's only a ui event
- Movie - don't generate new JS code when it's only a ui event
- Music - don't disable submission button if there is a ui event triggered after running code (this game requires running code before submission to gallery)
- Turtle - correctly monitor if the user clicks on a toolbox category (important for level hint)

This should be merged after Blockly's December release (as it depends on api changes made there).