### PR TITLE
Update Blockly Games for March 2021 release of Blockly

### DIFF
--- a/appengine/js/lib-interface.js
+++ b/appengine/js/lib-interface.js
@@ -13,12 +13,12 @@
 goog.provide('BlocklyInterface');
 
 goog.require('Blockly');
+goog.require('Blockly.ContextMenuItems');
+goog.require('Blockly.ShortcutItems');
 goog.require('Blockly.geras.Renderer');
 goog.require('BlocklyGames');
 goog.require('BlocklyGames.Msg');
 goog.require('BlocklyStorage');
-goog.require('Blockly.ShortcutItems');
-goog.require('Blockly.ContextMenuItems');
 
 
 /**

--- a/appengine/js/lib-interface.js
+++ b/appengine/js/lib-interface.js
@@ -17,6 +17,8 @@ goog.require('Blockly.geras.Renderer');
 goog.require('BlocklyGames');
 goog.require('BlocklyGames.Msg');
 goog.require('BlocklyStorage');
+goog.require('Blockly.ShortcutItems');
+goog.require('Blockly.ContextMenuItems');
 
 
 /**

--- a/appengine/movie/js/movie.js
+++ b/appengine/movie/js/movie.js
@@ -351,7 +351,7 @@ Movie.drawFrame_ = function(interpreter) {
  * @param {!Blockly.Events.Abstract=} opt_e Change event.
  */
 Movie.codeChange = function(opt_e) {
-  if (opt_e.isUiEvent) {
+  if (opt_e && opt_e.isUiEvent) {
     return;
   }
   if (BlocklyInterface.workspace.isDragging()) {

--- a/appengine/puzzle/js/puzzle.js
+++ b/appengine/puzzle/js/puzzle.js
@@ -113,7 +113,7 @@ Puzzle.init = function() {
     // Position the blocks randomly.
     var MARGIN = 50;
     Blockly.svgResize(BlocklyInterface.workspace);
-    var workspaceBox = Blockly.svgSize(BlocklyInterface.workspace.getParentSvg());
+    var workspaceBox = BlocklyInterface.workspace.getCachedParentSvgSize();
     workspaceBox.width -= MARGIN;
     workspaceBox.height -= MARGIN;
     var countedArea = 0;


### PR DESCRIPTION
There are a few pieces to this PR: 
- As of the March 2021 release of Blockly, `Blockly.ShortcutItems` and `Blockly.ContextMenuItems` got moved to `requires.js`. (See [this discussion](https://github.com/google/blockly/pull/4681#discussion_r588745776) for more information). 
- Bug fix in movie game.
- Remove a deprecated function in the puzzle game.