### PR TITLE
Add Inari Sámi to list of languages

### DIFF
--- a/appengine/common/boot.js
+++ b/appengine/common/boot.js
@@ -27,8 +27,8 @@ if (location.host === 'blockly-games.appspot.com') {
     'el', 'en', 'eo', 'es', 'eu', 'fa', 'fi', 'fo', 'fr', 'gl', 'ha', 'he',
     'hi', 'hr', 'hu', 'hy', 'ia', 'id', 'ig', 'is', 'it', 'ja', 'kab', 'kn',
     'ko', 'lt', 'lv', 'ms', 'my', 'nb', 'nl', 'pl', 'pms', 'pt', 'pt-br',
-    'ro', 'ru', 'sc', 'sk', 'sl', 'sq', 'sr', 'sr-latn', 'sv', 'th', 'ti',
-    'tr', 'uk', 'ur', 'vi', 'yo', 'zh-hans', 'zh-hant'
+    'ro', 'ru', 'sc', 'sk', 'sl', 'smn', 'sq', 'sr', 'sr-latn', 'sv', 'th',
+    'ti', 'tr', 'uk', 'ur', 'vi', 'yo', 'zh-hans', 'zh-hant'
   ];
 
   // Use a series of heuristics that determine the likely language of this user.

--- a/appengine/src/lib-games.js
+++ b/appengine/src/lib-games.js
@@ -78,7 +78,7 @@ BlocklyGames.LANGUAGE_NAME_ = {
   'ms': 'Bahasa Melayu',
   'my': 'မြန်မာစာ',
 //  'mzn': 'مازِرونی',  // RTL
-  'nb': 'Norsk Bokmål',
+  'nb': 'Norsk (bokmål)',
   'nl': 'Nederlands, Vlaams',
 //  'oc': 'Lenga d\'òc',
 //  'pa': 'पंजाबी',
@@ -94,6 +94,7 @@ BlocklyGames.LANGUAGE_NAME_ = {
 //  'si': 'සිංහල',
   'sk': 'Slovenčina',
   'sl': 'Slovenščina',
+  'smn': 'Anarâškielâ',
   'sq': 'Shqip',
   'sr': 'Српски',
   'sr-latn': 'Srpski',


### PR DESCRIPTION
Add Inari Sámi, which is above the 25% threshold, to the list of languages for the app. Also change the display name of my native language (Norwegian Bokmål).