### PR TITLE
remove svn as dependency and fix make deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ deps:
 	wget -N https://unpkg.com/@babel/standalone@7.14.8/babel.min.js
 	mv babel.min.js appengine/third-party/
 	@# GitHub doesn't support git archive, so download files using svn.
-	./svn-export-fix.sh ajaxorg ace-builds master src-min-noconflict appengine/third-party/ace
-	./svn-export-fix.sh NeilFraser blockly-for-BG master . appengine/third-party/blockly
-	./svn-export-fix.sh CreateJS SoundJS master lib appengine/third-party/SoundJS
+	./svn-export-fix.sh ajaxorg ace-builds master appengine/third-party/ace src-min-noconflict 
+	./svn-export-fix.sh NeilFraser blockly-for-BG master appengine/third-party/blockly
+	./svn-export-fix.sh CreateJS SoundJS master appengine/third-party/SoundJS lib
 
 	cp third-party/base.js appengine/third-party/
 	cp -R third-party/soundfonts appengine/third-party/
 
-	./svn-export-fix.sh NeilFraser JS-Interpreter master . appengine/third-party/JS-Interpreter
+	./svn-export-fix.sh NeilFraser JS-Interpreter master appengine/third-party/JS-Interpreter
 	@# Compile JS-Interpreter using SIMPLE_OPTIMIZATIONS because the Music game needs to mess with the stack.
 	java -jar build/third-party-downloads/closure-compiler.jar\
 	  --language_out ECMASCRIPT5\

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Definitions
 ##############################
 
-REQUIRED_BINS = svn wget java python
+REQUIRED_BINS = wget java python
 
 ##############################
 # Rules
@@ -60,14 +60,14 @@ deps:
 	wget -N https://unpkg.com/@babel/standalone@7.14.8/babel.min.js
 	mv babel.min.js appengine/third-party/
 	@# GitHub doesn't support git archive, so download files using svn.
-	svn export --force https://github.com/ajaxorg/ace-builds/trunk/src-min-noconflict/ appengine/third-party/ace
-	mkdir -p appengine/third-party/blockly
-	svn export --force https://github.com/NeilFraser/blockly-for-BG/trunk/ appengine/third-party/blockly
-	svn export --force https://github.com/CreateJS/SoundJS/trunk/lib/ appengine/third-party/SoundJS
+	./svn-export-fix.sh ajaxorg ace-builds master src-min-noconflict appengine/third-party/ace
+	./svn-export-fix.sh NeilFraser blockly-for-BG master . appengine/third-party/blockly
+	./svn-export-fix.sh CreateJS SoundJS master lib appengine/third-party/SoundJS
+
 	cp third-party/base.js appengine/third-party/
 	cp -R third-party/soundfonts appengine/third-party/
 
-	svn export --force https://github.com/NeilFraser/JS-Interpreter/trunk/ appengine/third-party/JS-Interpreter
+	./svn-export-fix.sh NeilFraser JS-Interpreter master . appengine/third-party/JS-Interpreter
 	@# Compile JS-Interpreter using SIMPLE_OPTIMIZATIONS because the Music game needs to mess with the stack.
 	java -jar build/third-party-downloads/closure-compiler.jar\
 	  --language_out ECMASCRIPT5\

--- a/svn-export-fix.sh
+++ b/svn-export-fix.sh
@@ -1,0 +1,21 @@
+if [ $# -ne 5 ]; then
+  echo "Usage: `basename $0` [github_user] [github_repo] [branch] [repo_dir] [dest_dir]"
+  exit 0
+fi
+
+DEST_DIR=$5
+SOURCE_URL=https://github.com/$1/$2/archive/refs/heads/$3.tar.gz
+SOURCE_DIR=$2-$3/$4
+
+curl -sILf $SOURCE_URL | grep "^content-type: application/x-gzip" 1>/dev/null
+
+if [ $? -ne 0 ]; then
+  echo "GitHub repo '$1/$2' does not exist or does not have the '$3' branch"
+  exit 1
+fi
+
+rm -rf $DEST_DIR/* 2>/dev/null
+mkdir -p $DEST_DIR/.temp
+curl -sL $SOURCE_URL | tar -xf - --directory=$DEST_DIR/.temp $SOURCE_DIR
+mv $DEST_DIR/.temp/$SOURCE_DIR/* $DEST_DIR
+rm -r $DEST_DIR/.temp

--- a/svn-export-fix.sh
+++ b/svn-export-fix.sh
@@ -1,21 +1,39 @@
-if [ $# -ne 5 ]; then
-  echo "Usage: `basename $0` [github_user] [github_repo] [branch] [repo_dir] [dest_dir]"
+if [ $# -ne 5 ] && [ $# -ne 4 ]; then
+  echo "Usage: `basename $0` <github_user> <github_repo> <branch> <dest_dir> [<repo_dir>]"
+  echo
+  echo "if <repo_dir> is omitted then the entire repo archive is unpacked into <dest_dir>"
   exit 0
 fi
 
-DEST_DIR=$5
+DEST_DIR=./$4
 SOURCE_URL=https://github.com/$1/$2/archive/refs/heads/$3.tar.gz
-SOURCE_DIR=$2-$3/$4
+if [ $# -ne 5 ]; then
+  SOURCE_DIR=$2-$3
+else
+  SOURCE_DIR=$2-$3/$5
+fi
 
-curl -sILf $SOURCE_URL | grep "^content-type: application/x-gzip" 1>/dev/null
+# fetches the headers (-I) while following redirects (-L) in fail mode (-f)
+# in this case the cURL command fails if redirects do not result in HTTP 200
+# while the GNU regex pattern command ensures that an archive is encountered
+# together they ensure that there is a .tar-gz archive at the source URL
+curl -sILf $SOURCE_URL | grep "^content-type: \+application/x-gzip" 1>/dev/null
 
 if [ $? -ne 0 ]; then
   echo "GitHub repo '$1/$2' does not exist or does not have the '$3' branch"
   exit 1
 fi
 
-rm -rf $DEST_DIR/* 2>/dev/null
+if [ -d $DEST_DIR ]; then rm -rf $DEST_DIR; fi
 mkdir -p $DEST_DIR/.temp
+
 curl -sL $SOURCE_URL | tar -xf - --directory=$DEST_DIR/.temp $SOURCE_DIR
+
+if [ ! -d $DEST_DIR/.temp/$SOURCE_DIR ]; then
+  echo "Unfamiliar archive content structure encountered on GitHub repo '$1/$2' (branch $3)"
+  rm -rf $DEST_DIR/.temp 2>/dev/null
+  exit 2
+fi
+
 mv $DEST_DIR/.temp/$SOURCE_DIR/* $DEST_DIR
-rm -r $DEST_DIR/.temp
+rm -rf $DEST_DIR/.temp


### PR DESCRIPTION
Following the sunsetting of Subversion control by GitHub, the Makefile workflow started breaking.

To fix this I created a script which I called `svn-export-fix.sh` and dropped `svn` as a dependency in the Makefile